### PR TITLE
new action which is triggered only when docs change in main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ name: deploy-book
 # Only run this when the master branch changes
 on:
   push:
-    branches:
-    - doc
+    branches: ['main']
+    paths: ['docs/**']
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:


### PR DESCRIPTION
merged doc with main. updated the action, so that web page generation triggers only when files in docs folder are changed in main branch. Thus updating the notebook themselves does not trigger regeneration of web page.